### PR TITLE
Async refresh

### DIFF
--- a/pebble-extension/src/browser/core.ts
+++ b/pebble-extension/src/browser/core.ts
@@ -198,11 +198,12 @@ export class PebbleCore {
       try {
         const root = await PebbleApi.connect(connectionNode.connection);
         connectionNode.loaded = true;
-        connectionNode.db = await this.addCollection(connectionNode, root)
-        connectionNode.db.loaded = true;
-        root.collections.forEach(subCollection => this.addCollection(connectionNode.db, subCollection));
-        root.documents.forEach(document => this.addDocument(connectionNode.db, document));
-        this.expand(connectionNode.db);
+        // connectionNode.db = await this.addCollection(connectionNode, root);
+        // connectionNode.db.loaded = true;
+        // root.collections.forEach(subCollection => this.addCollection(connectionNode, subCollection));
+        this.addCollection(connectionNode, root.collections[0]);
+        // root.documents.forEach(document => this.addDocument(connectionNode, document));
+        // this.expand(connectionNode.db);
         connectionNode.security = await this.addSecurity(connectionNode);
         connectionNode.indexes = await this.addIndexes(connectionNode);
       } catch (error) {

--- a/pebble-extension/src/browser/view-service.ts
+++ b/pebble-extension/src/browser/view-service.ts
@@ -26,8 +26,8 @@ export class PebbleViewService implements WidgetFactory {
       const document = node as PebbleDocumentNode;
       document.editor = await this.core.openDocument(document);
       this.widget && this.widget.model.refresh();
-    } else if (PebbleNode.isCollection(node as any)) {
-      this.core.refresh(node as any);
+    } else if (PebbleNode.isConnection(node as any)) {
+      this.core.showPropertiesDialog();
     }
   }
   

--- a/pebble-extension/src/browser/view-service.ts
+++ b/pebble-extension/src/browser/view-service.ts
@@ -35,7 +35,7 @@ export class PebbleViewService implements WidgetFactory {
     if (!this.widget) {
       return;
     }
-    if (node.expanded) {
+    if (node.expanded && PebbleNode.isContainer(node)) {
       this.core.expanded(node);
     }
   }

--- a/pebble-extension/src/classes/node.ts
+++ b/pebble-extension/src/classes/node.ts
@@ -9,12 +9,12 @@ export interface PebbleNode extends TreeNode {
   connectionNode: PebbleConnectionNode;
   uri: string;
   loading?: boolean;
+  loaded?: boolean;
 }
 export interface PebblecontainerNode extends PebbleNode, CompositeTreeNode, ExpandableTreeNode {}
 
 export interface PebbleConnectionNode extends PebbleNode, PebblecontainerNode, SelectableTreeNode {
   type: 'connection';
-  loaded?: boolean;
   connection: PebbleConnection;
   db: PebbleCollectionNode;
   security: PebbleSecurityNode
@@ -26,7 +26,6 @@ export interface PebbleToolbarNode extends PebbleNode {
 export interface PebbleItemNode extends PebbleNode, SelectableTreeNode {
   // type: 'item';
   link: string;
-  loaded?: boolean;
   isCollection: boolean;
 }
 export interface PebbleCollectionNode extends PebbleItemNode, PebblecontainerNode {

--- a/pebble-extension/src/common/api.ts
+++ b/pebble-extension/src/common/api.ts
@@ -131,7 +131,7 @@ export namespace PebbleApi {
   }
   
   export async function connect(connection: PebbleConnection): Promise<PebbleCollection> {
-    const root = await load(connection, '/db') as PebbleCollection;
+    const root = await load(connection, '/') as PebbleCollection;
     return root;
   }
 

--- a/pebble-extension/src/common/api.ts
+++ b/pebble-extension/src/common/api.ts
@@ -181,7 +181,10 @@ export namespace PebbleApi {
   }
 
   export async function getUsers(connection: PebbleConnection): Promise<string[]> {
-    return (await _get(connection, '/exist/restxq/pebble/user')).json();
+    const result = await (await _get(connection, '/exist/restxq/pebble/user')).json();
+    connection.users.length = 0;
+    connection.users.push(...result);
+    return result;
   }
 
   export async function getUser(connection: PebbleConnection, user: string): Promise<PebbleUser> {
@@ -217,7 +220,10 @@ export namespace PebbleApi {
   }
 
   export async function getGroups(connection: PebbleConnection): Promise<string[]> {
-    return (await _get(connection, '/exist/restxq/pebble/group')).json();
+    const result = await (await _get(connection, '/exist/restxq/pebble/group')).json();
+    connection.groups.length = 0;
+    connection.groups.push(...result);
+    return result;
   }
 
   export async function getGroup(connection: PebbleConnection, group: string): Promise<PebbleGroup> {


### PR DESCRIPTION
when expending an item in the tree, pebble try to update its content in the background, this works for:
- collections
- users
- groups
- indexes